### PR TITLE
Fixed missing type info in object register when returning from sys call

### DIFF
--- a/as_jit.cpp
+++ b/as_jit.cpp
@@ -3829,6 +3829,7 @@ void SystemCall::call_64conv(asSSystemFunctionInterface* func,
 		if(sFunc->returnType.IsObjectHandle()) {
 			Register ret = as<void*>(cpu.intReturn64());
 			as<void*>(*ebp + offsetof(asSVMRegisters,objectRegister)) = ret;
+            as<void*>(*ebp + offsetof(asSVMRegisters,objectType)) = sFunc->returnType.GetTypeInfo();
 
 			//Add reference for returned auto handle
 			if(func->returnAutoHandle) {
@@ -3897,7 +3898,7 @@ void SystemCall::call_64conv(asSSystemFunctionInterface* func,
 				//Technically need to clear the objectRegister
 				//However, anything that tries to read this when it isn't valid is making a mistake
 				//as<void*>(*ebp + offsetof(asSVMRegisters,objectRegister)) = nullptr;
-				int destruct = sFunc->returnType.GetBehaviour()->destruct;
+                int destruct = sFunc->returnType.GetBehaviour()->destruct;
 				if(destruct > 0) {
 					asCScriptFunction* destructFunc = (asCScriptFunction*)sFunc->GetEngine()->GetFunctionById(destruct);
 
@@ -3959,6 +3960,7 @@ void SystemCall::call_getReturn(asSSystemFunctionInterface* func, asCScriptFunct
 			}
 
 			as<void*>(*ebp + offsetof(asSVMRegisters,objectRegister)) = eax;
+            as<void*>(*ebp + offsetof(asSVMRegisters,objectType)) = sFunc->returnType.GetTypeInfo();
 
 			//Add reference for returned auto handle
 			if(func->returnAutoHandle) {
@@ -4015,6 +4017,7 @@ void SystemCall::call_getReturn(asSSystemFunctionInterface* func, asCScriptFunct
 			else {
 				//Store object pointer
 				as<void*>(*ebp + offsetof(asSVMRegisters,objectRegister)) = ecx;
+                as<void*>(*ebp + offsetof(asSVMRegisters,objectType)) = sFunc->returnType.GetTypeInfo();
 			}
 		}
 	}

--- a/as_jit.cpp
+++ b/as_jit.cpp
@@ -3898,7 +3898,7 @@ void SystemCall::call_64conv(asSSystemFunctionInterface* func,
 				//Technically need to clear the objectRegister
 				//However, anything that tries to read this when it isn't valid is making a mistake
 				//as<void*>(*ebp + offsetof(asSVMRegisters,objectRegister)) = nullptr;
-                int destruct = sFunc->returnType.GetBehaviour()->destruct;
+				int destruct = sFunc->returnType.GetBehaviour()->destruct;
 				if(destruct > 0) {
 					asCScriptFunction* destructFunc = (asCScriptFunction*)sFunc->GetEngine()->GetFunctionById(destruct);
 


### PR DESCRIPTION
I have found a bug in the JIT that crashes the VM when a native function exposed to the scripts both returns a reference or handle value and suspends the execution of the VM: if the execution is not continued before releasing the context, the VM crashes, because the object type register is set random memory.

This is because the JIT does not set the object type during a system call (it only sets the objectRegister). It probably works in standard scenarios because the asBC_STOREOBJ instruction is called right after, but if execution is suspended during the system call, the VM is in an unstable state.

Here is a proposal to fix this issue, simply setting the objectType pointer together with the objectRegister. Tested on Windows only so far, but it is probably not impacting other platforms either.
